### PR TITLE
Fixed JS error in case shipping method was unset by some service.

### DIFF
--- a/view/frontend/web/js/action/payment/select-payment-method.js
+++ b/view/frontend/web/js/action/payment/select-payment-method.js
@@ -12,7 +12,9 @@ define(
 
         return function (paymentMethod) {
             quote.paymentMethod(paymentMethod);
-            totals(isLoading, paymentMethod['method']);
+			if (paymentMethod){
+            	totals(isLoading, paymentMethod['method']);
+			}
         }
     }
 );


### PR DESCRIPTION
As written in description, in case some additional JS unset delivery method, code will create JS error and checkout 2nd step couldn't be loaded. This pull request fix such situations.